### PR TITLE
fix a bug(may be)

### DIFF
--- a/sources/org/workflowsim/WorkflowDatacenter.java
+++ b/sources/org/workflowsim/WorkflowDatacenter.java
@@ -280,7 +280,7 @@ public class WorkflowDatacenter extends Datacenter {
                         /**
                          * Picks up the site that is closest
                          */
-                        if (cl.getClassType() == ClassType.STAGE_IN.value) {
+                        //if (cl.getClassType() == ClassType.STAGE_IN.value) {
                             double maxRate = Double.MIN_VALUE;
                             for (Storage storage : getStorageList()) {
                                 double rate = storage.getMaxTransferRate();
@@ -290,7 +290,7 @@ public class WorkflowDatacenter extends Datacenter {
                             }
                             //Storage storage = getStorageList().get(0);
                             time += file.getSize() / maxRate;
-                        }
+                        //}
                         break;
                     case LOCAL:
                         int vmId = cl.getVmId();


### PR DESCRIPTION
before enter to the processDataStageIn(),classtype has already be limited to ClassType.COMPUTE.value, with another limit to STAGE_IN will result in this code never be executated.
the data transfer time will always be zero without fix the bug.
another question: what's the unite of bwth and rate ? seems they are quite different. 
thanks.